### PR TITLE
feat: support for raw notifications + Go modules

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,7 +73,11 @@ func (c *Client) Send(channelUri string, notification NotificationInterface) (su
 
 	xml, _ := notification.GetXml()
 	req, _ := http.NewRequest("POST", channelUri, bytes.NewBuffer([]byte(xml)))
-	req.Header.Add("Content-Type", "text/xml; charset=utf-8")
+	if notification.GetWnsType() == "wns/raw" {
+		req.Header.Add("Content-Type", "application/octet-stream")
+	} else {
+		req.Header.Add("Content-Type", "text/xml; charset=utf-8")
+	}
 	req.Header.Add("X-WNS-Type", notification.GetWnsType())
 	req.Header.Add("Authorization", "Bearer "+c.accessToken)
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Oniestel/go-wns
+
+go 1.16

--- a/notification.go
+++ b/notification.go
@@ -21,6 +21,10 @@ func NewTile() *baseNotification {
 	return newNotification(TypeTile)
 }
 
+func NewRaw() *raw {
+	return &raw{}
+}
+
 func NewBadge() *badge {
 	badge := &badge{}
 	badge.Type = TypeBadge

--- a/raw.go
+++ b/raw.go
@@ -1,0 +1,18 @@
+package wns
+
+type raw struct {
+	Body string
+}
+
+func (r *raw) SetBody(str string) *raw {
+	r.Body = str
+	return r
+}
+
+func (r *raw) GetXml() (string, error) {
+	return r.Body, nil
+}
+
+func (r *raw) GetWnsType() string {
+	return "wns/raw"
+}


### PR DESCRIPTION
Added support for WNS raw notifications such as what is used by Windows MDM. Go module support has also been added to allow the package to be correctly used with modern Go codebases.